### PR TITLE
Updates to Widgets.py

### DIFF
--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -481,16 +481,19 @@ class DateTimeBaseInput(TextInput):
 
 
 class DateInput(DateTimeBaseInput):
+    input_type = 'date'
     format_key = 'DATE_INPUT_FORMATS'
     template_name = 'django/forms/widgets/date.html'
 
 
 class DateTimeInput(DateTimeBaseInput):
+    input_type = 'datetime-local'
     format_key = 'DATETIME_INPUT_FORMATS'
     template_name = 'django/forms/widgets/datetime.html'
 
 
 class TimeInput(DateTimeBaseInput):
+    input_type = 'time'
     format_key = 'TIME_INPUT_FORMATS'
     template_name = 'django/forms/widgets/time.html'
 


### PR DESCRIPTION
Changed input_type attributes in DateInput, DatetimeInput and TimeInput widget classes to date, datetime-local and time input_type respectively, as against the  existing 'text' input_type defined in TextInput and inherited by DateTimeBaseInput from where the subclasses 
 above were created.